### PR TITLE
Fix streaming iterator state reset

### DIFF
--- a/libs/langchain/langchain/callbacks/streaming_aiter.py
+++ b/libs/langchain/langchain/callbacks/streaming_aiter.py
@@ -28,8 +28,10 @@ class AsyncIteratorCallbackHandler(AsyncCallbackHandler):
     async def on_llm_start(
         self, serialized: dict[str, Any], prompts: list[str], **kwargs: Any
     ) -> None:
+        """Reset internal state before a new LLM run."""
         # If two calls are made in a row, this resets the state
-        self.done.clear()
+        self.queue = asyncio.Queue()
+        self.done = asyncio.Event()
 
     async def on_llm_new_token(self, token: str, **kwargs: Any) -> None:
         if token is not None and token != "":

--- a/libs/langchain/tests/unit_tests/callbacks/test_streaming_aiter.py
+++ b/libs/langchain/tests/unit_tests/callbacks/test_streaming_aiter.py
@@ -1,0 +1,21 @@
+import asyncio
+
+from langchain.callbacks import AsyncIteratorCallbackHandler
+from langchain_core.outputs import LLMResult, Generation
+
+
+async def test_resets_between_runs() -> None:
+    handler = AsyncIteratorCallbackHandler()
+
+    # first run
+    await handler.on_llm_start({}, ["foo"])
+    await handler.on_llm_new_token("1")
+    await handler.on_llm_end(LLMResult(generations=[[Generation(text="")]]))
+
+    # second run
+    await handler.on_llm_start({}, ["bar"])
+    await handler.on_llm_new_token("2")
+    await handler.on_llm_end(LLMResult(generations=[[Generation(text="")]]))
+
+    tokens = [token async for token in handler.aiter()]
+    assert tokens == ["2"]


### PR DESCRIPTION
## Summary
- prevent token leakage between LLM runs in `AsyncIteratorCallbackHandler`
- add regression test for queue reset behaviour

## Testing
- `make test TEST_FILE=tests/unit_tests/callbacks/test_streaming_aiter.py`
- `make lint_package` *(fails: Interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_684ec9177df0832aa9682932078efa5c